### PR TITLE
Fix 'undefined method existent' error

### DIFF
--- a/lib/rails_engine_decorators/engine.rb
+++ b/lib/rails_engine_decorators/engine.rb
@@ -4,7 +4,7 @@ module RailsEngineDecorators
 
     included do
       initializer 'rails_engine_decorators.load' do
-        decorators = paths['app/decorators'].existent
+        decorators = paths['app/decorators'].existent rescue []
 
         if decorators.any?
           config.to_prepare do


### PR DESCRIPTION
Hello!
Thanks for this gem. We use it in our rails-projects. But in one project there was an error: 

/home/shredder/.rvm/gems/ruby-2.2.1/gems/rails_engine_decorators-1.0.0/lib/rails_engine_decorators/engine.rb:7:in `block (2 levels) in <module:Engine>': undefined method`existent' for nil:NilClass (NoMethodError)
    from /home/shredder/.rvm/gems/ruby-2.2.1/gems/railties-4.2.4/lib/rails/initializable.rb:30:in `instance_exec'
    from /home/shredder/.rvm/gems/ruby-2.2.1/gems/railties-4.2.4/lib/rails/initializable.rb:30:in`run'
    from /home/shredder/.rvm/gems/ruby-2.2.1/gems/railties-4.2.4/lib/rails/initializable.rb:55:in `block in run_initializers'

This pull request resolves the problem.
